### PR TITLE
Added style to messages, limited to 7 on screen

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,44 +1,64 @@
-.frame {
-    height: auto;
-    position: absolute;
-    width: 100%;
-    z-index: 100;
-    top: 0;
-    background-color: dodgerblue;
-    overflow-y: scroll;
-}
-
 .item {
     margin: 5px;
-    height: auto;
     background-color: white;
     font-size: 50px;
 }
 
-.red {
-    color: red;
+/* CSS talk bubble */
+.talk-bubble {
+    position: relative;
+    width: auto;
+    height: auto;
+    background-color: powderblue;
 }
 
-.blue {
-    color: blue;
+.border{
+    border: 8px solid #666;
 }
 
-.green {
-    color: green;
+.round{
+    border-radius: 30px;
+    -webkit-border-radius: 30px;
+    -moz-border-radius: 30px;
 }
 
-.orange {
-    color: orange;
+/*Right triangle, placed bottom left side slightly in*/
+.tri-right.border.btm-left-in:before {
+    content: ' ';
+    position: absolute;
+    width: 0;
+    height: 0;
+    left: 30px;
+    right: auto;
+    top: auto;
+    bottom: -40px;
+    border: 20px solid;
+    border-color: #666 transparent transparent #666;
 }
 
-.brown {
-    color: brown;
+.tri-right.btm-left-in:after{
+    content: ' ';
+    position: absolute;
+    width: 0;
+    height: 0;
+    left: 38px;
+    right: auto;
+    top: auto;
+    bottom: -20px;
+    border: 12px solid;
+    border-color: powderblue transparent transparent powderblue;
 }
 
-.purple {
-    color: purple;
+/* talk bubble contents */
+.talktext{
+    padding: .5em;
+    text-align: left;
+    line-height: 1.5em;
+    width: auto;
 }
 
-.black {
-    color: black;
+.talktext p{
+    /* remove webkit p margins */
+    -webkit-margin-before: 0em;
+    -webkit-margin-after: 0em;
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,7 +1,8 @@
-<div class="frame" ngx-auto-scroll>
-    <div *ngFor="let message of messages" class="item">
-        <div [ngStyle]="{'color': message.color}">
-            <p [ngStyle]="{'background-color': message.isNew ? 'yellow' : 'white'}">{{message.userName}}: {{message.content}}</p>
-        </div>
+<div *ngFor="let message of messages" class="talk-bubble tri-right border round btm-left-in item">
+    <div [ngStyle]="{'color': message.color}" class="talktext">
+        <p [ngStyle]="{'background-color': message.isNew ? 'yellow' : 'white'}">
+            {{message.userName}}: {{message.content}}
+        </p>
     </div>
 </div>
+<div id="bottom"></div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -41,12 +41,13 @@ export class AppComponent {
 
             let newMessage = new Message(userName, message, color);
             let number = this.messages.push(newMessage);
-
+            if (this.messages.length > 7) {
+                this.messages.shift();
+            }
+            
             let blinking = setInterval(() => {
                 this.messages[number - 1].isNew = !this.messages[number - 1].isNew;
             }, 1000);
-
-            window.scrollTo(window.innerWidth + 200, window.innerHeight + 200);
 
             setTimeout(() => {
                 clearInterval(blinking);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { NgxAutoScrollModule } from 'ngx-auto-scroll';
 import { HttpClientModule } from '@angular/common/http';
 
 import { AppComponent } from './app.component';
@@ -11,8 +10,7 @@ import { AppComponent } from './app.component';
   ],
   imports: [
     BrowserModule,
-    NgxAutoScrollModule,
-    HttpClientModule
+    HttpClientModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,4 +3,5 @@ body {
     top: 0;
     padding: 0;
     margin: 0;
+    background-color: dodgerblue;
 }


### PR DESCRIPTION
Updated the style of the messages to look like chat bubbles. Added a feature to create a scrolling effect while keeping the messages on the screen. Messages array will only story the most recent 7 messages and shift() from the beginning to remove a message at 7 or more messages. This keeps us from needing to figure out an auto scrolling solution.